### PR TITLE
Fix prepa timing and operator progress

### DIFF
--- a/V013.html
+++ b/V013.html
@@ -1836,9 +1836,9 @@ summary { cursor:pointer; }
 
   async function finishChange() {
     if (state.marks.some(m => m.kind === 'end')) return;
-    const now = Date.now();
+    const nowMs = Date.now();
     if (state.runningSince) {
-      const delta = now - state.runningSince;
+      const delta = nowMs - state.runningSince;
       state.sessionElapsedMs += delta;
       if (state.activePhase === 'Prépa chgt de PO') {
         state.prepaElapsedMs += delta;
@@ -1847,14 +1847,21 @@ summary { cursor:pointer; }
       }
       state.runningSince = null;
     }
-    finalizePrepaSegment(now);
+    finalizePrepaSegment(nowMs);
     addEvent('Fin du changement', { kind: 'end' });
     cancelAnimationFrame(runtime.animationFrame);
     updateDisplay();
     showToast('Changement terminé');
-    const poSafe = (state.po && state.po.trim() ? state.po.trim() : 'PO').replace(/[^\w-]+/g, '_') || 'PO';
-    const lineSafe = (state.line && state.line.trim() ? state.line.trim() : 'L29').replace(/[^\w-]+/g, '_') || 'L29';
-    const stamp = new Date().toISOString().slice(0, 16).replace(/:/g, '-');
+    const now = new Date(nowMs);
+    const pad = value => String(value).padStart(2, '0');
+    const sanitizeSegment = (value, fallback) => {
+      const base = value && value.trim() ? value.trim() : fallback;
+      const normalized = base.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+      return normalized.replace(/[^A-Za-z0-9_-]+/g, '_') || fallback;
+    };
+    const poSafe = sanitizeSegment(state.po, 'PO');
+    const lineSafe = sanitizeSegment(state.line, 'L29');
+    const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}-${pad(now.getMinutes())}`;
     const filename = `SMED_${lineSafe}_${poSafe}_${stamp}.html`;
     await exportHtml({ filename, forceSave: true });
   }
@@ -1928,6 +1935,7 @@ summary { cursor:pointer; }
     const rawLineLabel = state.line && state.line.trim() ? state.line.trim() : 'L29';
     const reportLine = escapeHtml(rawLineLabel);
     const lineSegment = rawLineLabel.replace(/[^\w-]+/g, '_') || 'L29';
+    const reportContent = buildReportHtml();
     const template = `<!DOCTYPE html>
 <html lang="fr">
 <head>
@@ -1967,7 +1975,7 @@ body{font-family:"Inter","Segoe UI",sans-serif;margin:40px;background:#f4f6fb;co
 </style>
 </head>
 <body>
-${buildReportHtml()}
+${reportContent}
 </body>
 </html>`;
     const filename = options.filename || `smed_${lineSegment}_${Date.now()}.html`;
@@ -1984,6 +1992,9 @@ ${buildReportHtml()}
         return;
       } catch (err) {
         console.error('Export HTML annulé ou impossible', err);
+        if (err && err.name === 'AbortError') {
+          return;
+        }
       }
     }
     downloadFile(filename, template, 'text/html');

--- a/V013.html
+++ b/V013.html
@@ -1090,6 +1090,7 @@ summary { cursor:pointer; }
     alertMin: 12,
     elapsedMs: 0,
     prepaElapsedMs: 0,
+    prepaRunningSince: null,
     activePhase: 'Prépa chgt de PO',
     marks: [],
     sessionStart: Date.now(),
@@ -1243,6 +1244,7 @@ summary { cursor:pointer; }
     }));
     if (!Number.isFinite(merged.elapsedMs)) merged.elapsedMs = 0;
     if (!Number.isFinite(merged.prepaElapsedMs)) merged.prepaElapsedMs = 0;
+    if (!Number.isFinite(merged.prepaRunningSince)) merged.prepaRunningSince = null;
     if (!Number.isFinite(merged.sessionElapsedMs)) merged.sessionElapsedMs = 0;
     if (!merged.sessionStart) merged.sessionStart = Date.now();
     if (!merged.activePhase || !phasesList.includes(merged.activePhase)) merged.activePhase = 'Prépa chgt de PO';
@@ -1400,14 +1402,6 @@ summary { cursor:pointer; }
       });
 
       const completedSetForPhase = state.completedOpsByOp[operatorName][state.activePhase];
-      const completed = completedSetForPhase.size || 0;
-      const pct = phaseOps.length ? Math.round((completed/phaseOps.length)*100) : 0;
-
-      card.innerHTML = `<div class="operator-header">
-          <h3>${escapeHtml(operatorName)}</h3>
-          <span class="progress-text">${pct}%</span>
-        </div>`;
-
       const doneOps = [];
       const todoOps = [];
 
@@ -1417,6 +1411,14 @@ summary { cursor:pointer; }
         const target = isDone ? doneOps : todoOps;
         target.push({ operation, opIndex, isDone });
       });
+
+      const completed = doneOps.length;
+      const pct = phaseOps.length ? Math.min(100, Math.round((completed/phaseOps.length)*100)) : 0;
+
+      card.innerHTML = `<div class="operator-header">
+          <h3>${escapeHtml(operatorName)}</h3>
+          <span class="progress-text">${pct}%</span>
+        </div>`;
 
       const buildPill = (operation, opIndex, isDone) => {
         const pill = document.createElement('button');
@@ -1595,12 +1597,20 @@ summary { cursor:pointer; }
     updateAnalysisDelayed();
   }
 
+  function finalizePrepaSegment(now = Date.now()) {
+    if (!state.prepaRunningSince) return;
+    const delta = Math.max(0, now - state.prepaRunningSince);
+    state.prepaElapsedMs += delta;
+    state.sessionElapsedMs += delta;
+    state.prepaRunningSince = null;
+  }
+
   function changePhase(phase) {
     if (!phasesList.includes(phase)) return;
     if (state.activePhase === phase) return;
     const previousPhase = state.activePhase;
+    const now = Date.now();
     if (state.runningSince) {
-      const now = Date.now();
       const delta = now - state.runningSince;
       state.sessionElapsedMs += delta;
       if (previousPhase === 'Prépa chgt de PO') {
@@ -1609,8 +1619,13 @@ summary { cursor:pointer; }
         state.elapsedMs += delta;
       }
       state.runningSince = now;
+    } else if (previousPhase === 'Prépa chgt de PO') {
+      finalizePrepaSegment(now);
     }
     state.activePhase = phase;
+    if (phase === 'Prépa chgt de PO' && !state.runningSince && !state.prepaRunningSince) {
+      state.prepaRunningSince = now;
+    }
     const hasStarted = state.marks.some(m => m.kind === 'start');
     if (els.start) {
       if (phase === 'Prépa chgt de PO') {
@@ -1647,7 +1662,15 @@ summary { cursor:pointer; }
   }
 
   function getSessionElapsed() {
-    return state.sessionElapsedMs + (state.runningSince ? Date.now() - state.runningSince : 0);
+    const now = Date.now();
+    let total = state.sessionElapsedMs;
+    if (state.runningSince) {
+      total += Math.max(0, now - state.runningSince);
+    }
+    if (state.prepaRunningSince) {
+      total += Math.max(0, now - state.prepaRunningSince);
+    }
+    return total;
   }
 
   function startTimer() {
@@ -1812,8 +1835,8 @@ summary { cursor:pointer; }
 
   async function finishChange() {
     if (state.marks.some(m => m.kind === 'end')) return;
+    const now = Date.now();
     if (state.runningSince) {
-      const now = Date.now();
       const delta = now - state.runningSince;
       state.sessionElapsedMs += delta;
       if (state.activePhase === 'Prépa chgt de PO') {
@@ -1823,6 +1846,7 @@ summary { cursor:pointer; }
       }
       state.runningSince = null;
     }
+    finalizePrepaSegment(now);
     addEvent('Fin du changement', { kind: 'end' });
     cancelAnimationFrame(runtime.animationFrame);
     updateDisplay();
@@ -2270,7 +2294,25 @@ ${buildReportHtml()}
     const field = input.dataset.field;
     if (!field) return;
     if (field === 'enabled') {
-      state.phases[phase][idx].enabled = input.checked;
+      const operation = state.phases[phase][idx];
+      operation.enabled = input.checked;
+      if (!operation.id) operation.id = row.dataset.id || newId();
+      if (!input.checked) {
+        ensureCompletedStructures();
+        const identifiers = [];
+        if (operation.id) identifiers.push(operation.id);
+        if (operation.name) identifiers.push(operation.name);
+        Object.keys(state.completedOpsByOp).forEach(operatorName => {
+          const byPhase = state.completedOpsByOp[operatorName];
+          if (!byPhase) return;
+          const set = byPhase[phase];
+          if (!(set instanceof Set)) return;
+          identifiers.forEach(identifier => {
+            if (!identifier) return;
+            set.delete(identifier);
+          });
+        });
+      }
       saveState();
       updatePhaseTotal(input.closest('table'), phase);
       updateTargets();
@@ -2522,6 +2564,11 @@ ${buildReportHtml()}
     els.mode.value = state.mode;
     if (els.line) els.line.value = state.line || '';
     updateBrandLine();
+    let prepaUpdated = false;
+    if (state.activePhase === 'Prépa chgt de PO' && !state.runningSince && !state.prepaRunningSince) {
+      state.prepaRunningSince = Date.now();
+      prepaUpdated = true;
+    }
     renderPhaseChips();
     renderOperatorColumns();
     updateTargets();
@@ -2554,6 +2601,9 @@ ${buildReportHtml()}
       requestTick();
     } else {
       cancelAnimationFrame(runtime.animationFrame);
+    }
+    if (prepaUpdated) {
+      saveState();
     }
   }
 
@@ -2593,12 +2643,15 @@ ${buildReportHtml()}
     els.reset.addEventListener('click', () => {
       if (!confirm('Réinitialiser la session ?')) return;
 
+      finalizePrepaSegment();
+
       // 1) Chrono & journal
       state.marks = [];
       state.elapsedMs = 0;
       state.prepaElapsedMs = 0;
       state.sessionElapsedMs = 0;
       state.runningSince = null;
+      state.prepaRunningSince = null;
       state.sessionStart = Date.now();
 
       // 2) Opérations validées -> vidage total

--- a/V013.html
+++ b/V013.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>SMED L29 – Suivi changement de PO</title>
+<link rel="preload" as="image" href="c9e2131f-5d59-4ed0-bb0b-d886a43a0b38.png" />
 <style>
 :root {
   --bg:#0f1a34;
@@ -841,7 +842,7 @@ summary { cursor:pointer; }
 <div id="splash" role="dialog" aria-label="Écran de lancement">
   <div class="splash-vignette">
     <div class="splash-logo-wrap logo-container">
-      <img src="smed-logo.png" alt="Logo SMED" class="splash-logo logo-image">
+      <img id="splashLogo" src="c9e2131f-5d59-4ed0-bb0b-d886a43a0b38.png" alt="Logo SMED" class="splash-logo logo-image">
       <span class="splash-logo-fallback logo-fallback-text" aria-hidden="true">SMED</span>
     </div>
     <div class="splash-caption">Chargement du tableau de bord…</div>
@@ -852,7 +853,7 @@ summary { cursor:pointer; }
     <div class="top-nav">
       <div class="brand">
         <div class="brand-mark logo-container">
-          <img src="smed-logo.png" alt="SMED" class="brand-logo logo-image">
+          <img src="c9e2131f-5d59-4ed0-bb0b-d886a43a0b38.png" alt="SMED" class="brand-logo logo-image">
           <span class="brand-logo-fallback logo-fallback-text" aria-hidden="true">SMED</span>
         </div>
         <span class="brand-sep" aria-hidden="true"></span>

--- a/V013.html
+++ b/V013.html
@@ -387,6 +387,9 @@ button:not(:disabled):active { transform:translateY(1px); }
   backdrop-filter:blur(8px);
 }
 .operator-badge.focused{box-shadow:0 0 0 3px rgba(61,220,151,.28);background:rgba(61,220,151,.22)}
+/* Rangée sous le nom opérateur pour la pastille HC */
+.op-hc-row{display:flex;align-items:center;gap:8px}
+.op-hc-row .hc-btn{border:none;cursor:pointer}
 .operator-header {
   display:flex;
   justify-content:space-between;
@@ -901,7 +904,7 @@ summary { cursor:pointer; }
                 </div>
                 <div class="main-actions">
                   <button id="start" class="primary" type="button"><span class="icon">▶</span>Démarrer</button>
-                  <button id="lap" class="secondary" type="button"><span class="icon">✦</span>Événement rapide</button>
+                  <button id="lap" class="secondary" type="button"><span class="icon">✦</span>Événement Hors changement</button>
                   <button id="end" class="warn" type="button"><span class="icon">■</span>Fin du changement</button>
                   <button id="reset" class="danger" type="button"><span class="icon">↺</span>Reset session</button>
                 </div>
@@ -977,7 +980,7 @@ summary { cursor:pointer; }
         </div>
       </div>
       <div class="panel compact events-panel">
-        <div class="panel-title"><h2>Évènements prédéfinis</h2><span class="label-muted">Utilisés par l'événement rapide</span></div>
+        <div class="panel-title"><h2>Évènements prédéfinis</h2><span class="label-muted">Utilisés par l'événement Hors changement</span></div>
         <form id="eventForm" class="event-form">
           <div class="field">
             <label>Nouvel événement<input type="text" id="eventInput" placeholder="Libellé d'événement"></label>
@@ -1386,6 +1389,21 @@ summary { cursor:pointer; }
       badge.addEventListener('click', () => { runtime.focusedOperator = idx; renderOperatorColumns(); });
       col.appendChild(badge);
 
+      // Ajout : pastille "Évènement Hors changement" sous le nom de l'opérateur
+      const hcRow = document.createElement('div');
+      hcRow.className = 'op-hc-row';
+      const hcBtn = document.createElement('button');
+      hcBtn.type = 'button';
+      hcBtn.className = 'badge hc hc-btn';
+      hcBtn.title = `Ajouter un évènement Hors changement pour ${operatorName}`;
+      hcBtn.textContent = 'Évènement Hors changement';
+      hcBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openOperatorHcMenu(idx, hcBtn);
+      });
+      hcRow.appendChild(hcBtn);
+      col.appendChild(hcRow);
+
       const card = document.createElement('div');
       card.className = 'operator-card' + (idx === runtime.focusedOperator ? ' focused' : '');
       card.dataset.index = idx;
@@ -1768,6 +1786,71 @@ summary { cursor:pointer; }
     saveState();
     renderLog();
     updateAnalysisDelayed();
+  }
+
+  // Ajout : créer un évènement Hors Changement (HC) pour un opérateur donné
+  function addHcEventForOperator(label, operatorName) {
+    state.marks.push({
+      t: getSessionElapsed(),
+      phase: state.activePhase,
+      operator: operatorName || '',
+      label,
+      kind: 'event',
+      note: '',
+      hc: true,
+      durationMs: 0
+    });
+    saveState();
+    renderLog();
+    updateAnalysisDelayed();
+  }
+
+  // Ajout : menu contextuel pour ajouter un évènement HC à un opérateur
+  function openOperatorHcMenu(operatorIndex, anchorEl) {
+    if (runtime.quickEventMenu) { closeQuickEventMenu(); return; }
+    const available = state.events.filter(label => label && label.trim());
+    const operatorName = getCurrentOperatorName(operatorIndex);
+
+    const menu = document.createElement('div');
+    menu.className = 'quick-event-menu';
+    menu.setAttribute('role', 'menu');
+
+    const useLabel = (txt) => {
+      addHcEventForOperator(txt, operatorName);
+      closeQuickEventMenu();
+    };
+
+    if (!available.length) {
+      const manual = prompt(`Libellé d'événement (HC) pour ${operatorName} :`);
+      if (manual && manual.trim()) useLabel(manual.trim());
+      return;
+    }
+
+    available.forEach(label => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = label;
+      btn.addEventListener('click', () => useLabel(label));
+      menu.appendChild(btn);
+    });
+
+    const custom = document.createElement('button');
+    custom.type = 'button';
+    custom.textContent = 'Autre…';
+    custom.addEventListener('click', () => {
+      const manual = prompt(`Libellé d'événement (HC) pour ${operatorName} :`);
+      if (manual && manual.trim()) useLabel(manual.trim());
+    });
+    menu.appendChild(custom);
+
+    document.body.appendChild(menu);
+    const rect = anchorEl.getBoundingClientRect();
+    menu.style.top  = `${rect.bottom + window.scrollY + 8}px`;
+    menu.style.left = `${rect.left + window.scrollX}px`;
+    runtime.quickEventMenu = menu;
+
+    document.addEventListener('click', handleQuickEventOutside, true);
+    document.addEventListener('keydown', handleQuickEventKeydown);
   }
 
   function openQuickEventMenu() {


### PR DESCRIPTION
## Summary
- start tracking Prépa (HC) elapsed time before the chrono begins and persist it through phase changes, reset and finish
- include ongoing hors-chrono deltas when computing session elapsed timestamps so journal entries advance correctly
- clamp operator progress to enabled operations and purge disabled steps from completion sets

## Testing
- not run (UI only)


------
https://chatgpt.com/codex/tasks/task_e_68d04c6fec10832db63c8c9e3f3d0169