### PR TITLE
Treat marked HC events as hors chrono

### DIFF
--- a/V013.html
+++ b/V013.html
@@ -2071,7 +2071,7 @@ ${buildReportHtml()}
       const duration = mark.durationMs || Math.max(0, mark.t - previousTime);
       const isPhaseChange = mark.kind === 'event' && mark.label?.toLowerCase().includes('changement de phase');
       const attributedPhase = isPhaseChange ? phaseContext : mark.phase;
-      const attributedHc = attributedPhase === 'Prépa chgt de PO';
+      const attributedHc = attributedPhase === 'Prépa chgt de PO' || mark.hc === true;
       if (!attributedHc) {
         totalChrono += duration;
         phaseDurations.set(attributedPhase, (phaseDurations.get(attributedPhase) || 0) + duration);


### PR DESCRIPTION
## Summary
- treat marks flagged with `hc` as hors chrono when computing analysis totals
- ensure hors chrono marks do not contribute to gap source metrics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0fb45d990832d91807b2e0ff0ba04